### PR TITLE
With this feature file will be saved in UTF-8 format and UTF-8 characters will be visible.

### DIFF
--- a/src/main/java/org/edla/dico/construct/DicoBuilder.java
+++ b/src/main/java/org/edla/dico/construct/DicoBuilder.java
@@ -17,9 +17,12 @@
 
 package org.edla.dico.construct;
 
+import java.io.BufferedWriter;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
@@ -32,8 +35,8 @@ import org.edla.wikimediaschema.RevisionType;
 public class DicoBuilder {
 
 	private Locator locator;
-	private FileWriter wordsWriter = null;
-	private FileWriter exclusWriter = null;
+	private BufferedWriter wordsWriter = null;
+	private BufferedWriter exclusWriter = null;
 	private String language;
 	private String languageShort;
 	private boolean expression;
@@ -51,8 +54,8 @@ public class DicoBuilder {
 						.println("and/or check/fix your config file dico.properties and try again.");
 				System.exit(1);
 			}
-			wordsWriter = new FileWriter(dicoProperties.wordsFile);
-			exclusWriter = new FileWriter(dicoProperties.exclusFile);
+			wordsWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(dicoProperties.wordsFile), StandardCharsets.UTF_8));
+			exclusWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(dicoProperties.exclusFile), StandardCharsets.UTF_8));
 			language = dicoProperties.language;
 			languageShort = dicoProperties.languageShort;
 			expression = dicoProperties.expression;


### PR DESCRIPTION
Hi Olivier,

When I was using this utility with Hindi and Marathi text, the dictionary file was getting created successfully using command "java -jar target/dictionary-builder.jar". But the text inside it was showing as "???". The file was not able to recognize the "UTF-8" characters.
So I checked the code and found that in "DicoBuilder.java" the output file was not opened in "UTF-8" mode.
I edited "UTF-8" related changes and then the dictionary file was coming clearly Hindi and Marathi characters successfully.